### PR TITLE
feat: broaden content creator with multi-tradition flow

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -88,6 +88,22 @@ ENABLE_QUERY_REFORMULATION = get_env_bool("ENABLE_QUERY_REFORMULATION", True)
 DEFAULT_SEARCH_K = get_env_int("DEFAULT_SEARCH_K", 5)
 MAX_TOTAL_EVIDENCE_CHUNKS = get_env_int("MAX_TOTAL_EVIDENCE_CHUNKS", 15)
 
+# Content creator settings
+CONTENT_CREATOR_TARGET_SCORE = get_env_int("CONTENT_CREATOR_TARGET_SCORE", 9)
+CONTENT_CREATOR_MAX_PASSES = get_env_int("CONTENT_CREATOR_MAX_PASSES", 5)
+DEFAULT_TRADITIONS = [
+    "Bhagavad Gita",
+    "Bible",
+    "Quran",
+    "Tao Te Ching",
+    "Dhammapada",
+]
+_traditions = os.getenv("CONTENT_CREATOR_TRADITIONS")
+if _traditions:
+    CONTENT_CREATOR_TRADITIONS = [t.strip() for t in _traditions.split(",") if t.strip()]
+else:
+    CONTENT_CREATOR_TRADITIONS = DEFAULT_TRADITIONS
+
 # =============================================================================
 # UI & PROGRESS
 # =============================================================================

--- a/app/modes/content_creator.py
+++ b/app/modes/content_creator.py
@@ -1,0 +1,193 @@
+"""
+Content Creator Mode - Generates social media hooks from sacred texts.
+
+This mode searches the vector store for passages related to a topic and
+crafts an engaging tweet that invites readers to explore other modes of the
+application.  It then auto-rates the tweet and optionally revises it based on a
+critique so that the final output is more compelling.
+"""
+
+from __future__ import annotations
+
+from typing import Generator, Dict, Any, List, Optional
+import json
+
+import ollama
+
+from app.modes.base import BaseMode
+from app.core.vector_store import VectorStore, ChromaVectorStore
+from app import config as agent_config
+
+
+class ContentCreatorMode(BaseMode):
+    """Mode for generating engaging tweets from sacred text passages."""
+
+    def __init__(self, llm_provider, vector_store):
+        super().__init__(llm_provider, vector_store)
+        if hasattr(vector_store, "query"):
+            self.store: VectorStore = ChromaVectorStore(vector_store)
+        else:
+            self.store = vector_store
+
+    def run(
+        self, query: str, chat_history: Optional[List[Dict]] = None
+    ) -> Generator[Dict[str, Any], None, str]:
+        """Create a tweet inspired by sacred texts.
+
+        The generator yields structured updates describing its progress and
+        returns the final tweet string.
+        """
+
+        results = []
+        traditions = agent_config.CONTENT_CREATOR_TRADITIONS
+
+        rating_prompt = (
+            "You are a meticulous social media editor. Rate the tweet from 1-10 "
+            "for engagement and suggest improvements. Respond in JSON with keys "
+            "'rating', 'critique', and 'improved'."
+        )
+
+        for trad in traditions:
+            # Step 1: Retrieve passages for each tradition
+            yield {
+                "type": "searching",
+                "tradition": trad,
+                "content": f"Searching {trad} for insights on: {query}",
+            }
+            try:
+                q_embed = ollama.embeddings(
+                    model=agent_config.EMBEDDING_MODEL,
+                    prompt=f"{query} {trad}",
+                )["embedding"]
+                sr = self.store.query_embeddings([q_embed], k=3)[0]
+                docs = sr.documents
+                metas = sr.metadatas
+            except Exception as e:  # pragma: no cover - defensive
+                yield {
+                    "type": "error",
+                    "tradition": trad,
+                    "content": f"Search error: {e}",
+                }
+                continue
+
+            passages = []
+            for doc, meta in zip(docs, metas):
+                source = meta.get("source", "Unknown source")
+                passages.append({"source": source, "text": doc})
+            yield {"type": "passages", "tradition": trad, "content": passages}
+
+            # Step 2: Draft tweet in authoritative voice
+            yield {
+                "type": "drafting",
+                "tradition": trad,
+                "content": "Crafting initial tweet...",
+            }
+            passages_text = "\n".join(
+                f"{i+1}. {p['text']}" for i, p in enumerate(passages)
+            )
+            prompt = f"""In a sharp, authoritative voice rooted in the {trad} tradition, craft a tweet (<=280 characters) linking the topic
+"{query}" to these passages:
+{passages_text}
+
+The tweet should:
+- offer a provocative hook into our 'contemplative' and 'deep_research' modes
+- avoid hashtags except #SacredTexts
+"""
+            try:
+                tweet = self.llm.generate_response(
+                    [
+                        {
+                            "role": "system",
+                            "content": "You craft terse, authoritative tweets based on passages.",
+                        },
+                        {"role": "user", "content": prompt},
+                    ],
+                    agent_config.OPENROUTER_CHAT_MODEL
+                    if agent_config.LLM_PROVIDER == "openrouter"
+                    else agent_config.OLLAMA_CHAT_MODEL,
+                ).strip()
+            except Exception as e:  # pragma: no cover - defensive
+                yield {
+                    "type": "error",
+                    "tradition": trad,
+                    "content": f"Tweet generation error: {e}",
+                }
+                continue
+
+            yield {
+                "type": "tweet_draft",
+                "tradition": trad,
+                "content": tweet,
+            }
+
+            # Step 3: Auto-rate with iterative critique
+            final_tweet = tweet
+            for i in range(agent_config.CONTENT_CREATOR_MAX_PASSES):
+                yield {
+                    "type": "evaluating",
+                    "tradition": trad,
+                    "content": f"Evaluating tweet (round {i + 1})...",
+                }
+                try:
+                    rating_response = self.llm.generate_response(
+                        [
+                            {"role": "system", "content": rating_prompt},
+                            {"role": "user", "content": final_tweet},
+                        ],
+                        agent_config.OPENROUTER_CHAT_MODEL
+                        if agent_config.LLM_PROVIDER == "openrouter"
+                        else agent_config.OLLAMA_CHAT_MODEL,
+                    )
+                    data = json.loads(rating_response)
+                except Exception as e:  # pragma: no cover - defensive
+                    yield {
+                        "type": "error",
+                        "tradition": trad,
+                        "content": f"Rating failed: {e}",
+                    }
+                    break
+
+                score = int(data.get("rating", 0))
+                critique = data.get("critique", "")
+                improved = data.get("improved", "")
+                yield {
+                    "type": "rating",
+                    "tradition": trad,
+                    "score": score,
+                    "critique": critique,
+                    "round": i + 1,
+                }
+
+                if (
+                    score >= agent_config.CONTENT_CREATOR_TARGET_SCORE
+                    or not improved
+                    or i == agent_config.CONTENT_CREATOR_MAX_PASSES - 1
+                ):
+                    if score < agent_config.CONTENT_CREATOR_TARGET_SCORE and improved:
+                        final_tweet = improved
+                        yield {
+                            "type": "revised",
+                            "tradition": trad,
+                            "content": "Tweet revised based on critique.",
+                            "round": i + 1,
+                        }
+                    break
+
+                final_tweet = improved
+                yield {
+                    "type": "revised",
+                    "tradition": trad,
+                    "content": "Tweet revised based on critique.",
+                    "round": i + 1,
+                }
+
+            results.append({"tradition": trad, "tweet": final_tweet})
+
+        yield {
+            "type": "complete",
+            "content": "Tweets prepared",
+            "results": results,
+        }
+        return "\n\n".join(
+            f"{r['tradition']}: {r['tweet']}" for r in results
+        )

--- a/app/modes/registry.py
+++ b/app/modes/registry.py
@@ -6,6 +6,7 @@ This registry is imported by both CLI and web interfaces to avoid duplication.
 
 from app.modes.deep_research import DeepResearchMode
 from app.modes.contemplative import ContemplativeMode
+from app.modes.content_creator import ContentCreatorMode
 
 
 # Single registry of all available modes
@@ -19,6 +20,11 @@ MODES = {
         "class": ContemplativeMode,
         "description": "Reflective mode that offers a passage and thoughtful question",
         "aliases": ["contemplate", "reflect"]
+    },
+    "content_creator": {
+        "class": ContentCreatorMode,
+        "description": "Generates an engaging tweet with auto-critique",
+        "aliases": ["tweet", "social"]
     }
 }
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+import sys
+import types
+
+
+if "ollama" not in sys.modules:
+    sys.modules["ollama"] = types.SimpleNamespace(
+        embeddings=lambda model, prompt: {"embedding": [0.0] * 768}
+    )
+
+if "chromadb" not in sys.modules:
+    sys.modules["chromadb"] = types.SimpleNamespace()
+

--- a/tests/test_content_creator_offline.py
+++ b/tests/test_content_creator_offline.py
@@ -1,0 +1,74 @@
+import json
+
+from app.modes.content_creator import ContentCreatorMode
+
+
+class DummyLLM:
+    def __init__(self):
+        self.calls = 0
+
+    def generate_response(self, messages, model):
+        group = self.calls // 3  # each group corresponds to one tradition
+        phase = self.calls % 3
+        self.calls += 1
+        if phase == 0:
+            return f"Tweet {group + 1} draft"
+        elif phase == 1:
+            return json.dumps(
+                {
+                    "rating": 6,
+                    "critique": "needs spice",
+                    "improved": f"Tweet {group + 1} improved",
+                }
+            )
+        else:
+            return json.dumps(
+                {
+                    "rating": 9,
+                    "critique": "solid",
+                    "improved": "",
+                }
+            )
+
+
+class DummyCollection:
+    def query(self, query_embeddings=None, n_results=3, include=None, **kwargs):
+        return {
+            "documents": [["Doc1", "Doc2", "Doc3"]],
+            "metadatas": [[{"source": "s1"}, {"source": "s2"}, {"source": "s3"}]],
+            "distances": [[0.1, 0.2, 0.3]],
+        }
+
+
+def test_content_creator_generates_five(monkeypatch):
+    import ollama
+
+    monkeypatch.setattr(
+        ollama, "embeddings", lambda model, prompt: {"embedding": [0.0] * 768}
+    )
+
+    mode = ContentCreatorMode(DummyLLM(), DummyCollection())
+    gen = mode.run("kindness")
+
+    updates = []
+    try:
+        while True:
+            try:
+                updates.append(next(gen))
+            except StopIteration as e:
+                final = e.value
+                break
+    except Exception as e:
+        raise AssertionError(f"Mode errored: {e}")
+
+    drafts = [u for u in updates if u.get("type") == "tweet_draft"]
+    ratings = [u for u in updates if u.get("type") == "rating"]
+    revisions = [u for u in updates if u.get("type") == "revised"]
+
+    assert len(drafts) == 5
+    assert len(ratings) >= 10
+    assert len(revisions) >= 5
+
+    for i in range(1, 6):
+        assert f"Tweet {i} improved" in final
+


### PR DESCRIPTION
## Summary
- let Content Creator roam across configurable sacred traditions, pulling context for each
- craft and refine a harsh, authoritative tweet per tradition via iterative auto-rating
- stub missing dependencies to keep offline tests green

## Testing
- `pytest tests/test_content_creator_offline.py tests/test_contemplative_offline.py tests/test_deep_research_offline.py tests/test_modes_contract.py tests/test_registry.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6107ed718832ca17094d2687eb310